### PR TITLE
fixes URL path cut off

### DIFF
--- a/src/EtherpadLite/Request.php
+++ b/src/EtherpadLite/Request.php
@@ -52,7 +52,9 @@ class Request
      */
     protected function getUrlPath()
     {
-        return sprintf(
+        $existingPath = parse_url($this->url, PHP_URL_PATH);
+
+        return $existingPath . sprintf(
             '/api/%s/%s',
             self::API_VERSION,
             $this->method


### PR DESCRIPTION
If you had installed your Etherpad-Lite in a sub folder, for example http://mypage.org/pad, the path '/pad' was cut off and the api call failed
